### PR TITLE
Add keyboard shortcut to drop orbs

### DIFF
--- a/client/src/factories/IconFactory.js
+++ b/client/src/factories/IconFactory.js
@@ -1,4 +1,4 @@
-import { ITEM_TYPE_BOMB, ITEM_TYPE_LIMITS } from "../constants.js";
+import { ITEM_TYPE_BOMB, ITEM_TYPE_LIMITS, ITEM_TYPE_ORB } from "../constants.js";
 
 class IconFactory {
     constructor(game) {
@@ -378,6 +378,40 @@ class IconFactory {
             if (wasSelected && this.game?.player) {
                 this.game.player.bombsArmed = false;
             }
+        }
+
+        this.game.forceDraw = true;
+        return dropInfo;
+    }
+
+    dropOrbFromInventory() {
+        const ownerId = this.game?.player?.id;
+        if (ownerId === null || ownerId === undefined) {
+            return null;
+        }
+
+        const orbIcon = this.findOwnedIconByType(ownerId, ITEM_TYPE_ORB);
+        if (!orbIcon) {
+            return null;
+        }
+
+        const quantityRaw = Number.isFinite(orbIcon.quantity)
+            ? orbIcon.quantity
+            : parseInt(orbIcon.quantity, 10) || 1;
+        const quantity = Math.max(1, quantityRaw);
+
+        const dropInfo = {
+            type: ITEM_TYPE_ORB,
+            owner: ownerId,
+            city: this.game.player?.city ?? null,
+            teamId: this.game.player?.city ?? null,
+            quantity: 1,
+        };
+
+        if (quantity > 1) {
+            orbIcon.quantity = quantity - 1;
+        } else {
+            this.deleteIcon(orbIcon);
         }
 
         this.game.forceDraw = true;

--- a/client/src/input/input-keyboard.js
+++ b/client/src/input/input-keyboard.js
@@ -189,6 +189,7 @@ export const setupKeyboardInputs = (game) => {    //Capture the keyboard arrow k
         d = keyboard(68),
         s = keyboard(83),
         b = keyboard(66),
+        o = keyboard(79),
         h = keyboard(72),
         c = keyboard(67),
         f = keyboard(70);
@@ -249,6 +250,20 @@ export const setupKeyboardInputs = (game) => {    //Capture the keyboard arrow k
         const dropInfo = game.iconFactory.dropBombFromInventory();
         if (!dropInfo) {
             console.log("No bombs available to deploy.");
+            return;
+        }
+
+        dropInventoryItem(game, dropInfo);
+    };
+
+    o.press = function () {
+        if (!game.iconFactory || typeof game.iconFactory.dropOrbFromInventory !== 'function') {
+            return;
+        }
+
+        const dropInfo = game.iconFactory.dropOrbFromInventory();
+        if (!dropInfo) {
+            console.log("No orbs available to deploy.");
             return;
         }
 


### PR DESCRIPTION
## Summary
- add a keyboard shortcut that drops an orb from inventory when pressing O
- extend the icon factory with an orb drop helper so the shortcut consumes inventory and notifies the game

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691342c92d6c832a82512ff61083fb5d)