### PR TITLE
Allow teammates to pick up placed mines

### DIFF
--- a/client/src/SocketListener.js
+++ b/client/src/SocketListener.js
@@ -674,11 +674,15 @@ class SocketListener extends EventEmitter2 {
         this.io.emit('hazard:arm', JSON.stringify(hazard));
     }
 
-    removeHazard(id) {
-        if (!this.io || this.io.disconnected || !id) {
+    removeHazard(hazard) {
+        if (!this.io || this.io.disconnected || !hazard) {
             return;
         }
-        this.io.emit('hazard:remove', JSON.stringify({ id }));
+        const payload = (typeof hazard === 'object') ? hazard : { id: hazard };
+        if (!payload.id) {
+            return;
+        }
+        this.io.emit('hazard:remove', JSON.stringify(payload));
     }
 
     spawnDefense(defense) {

--- a/client/src/collision/collision-helpers.js
+++ b/client/src/collision/collision-helpers.js
@@ -72,7 +72,8 @@ export const checkItems = (game, rect) => {
                     game.player.collidedItem = item;
                     return COLLISION_MINE;
                 }
-                // Friendly mines are intangible to the owner and teammates.
+                // Friendly mines are intangible to the owner and teammates but should remain selectable for pickup.
+                game.player.collidedItem = item;
             } else if (item.type === ITEM_TYPE_DFG && item.active !== false) {
                 const dfgTeam = item.teamId ?? item.city ?? null;
                 if (dfgTeam === null || dfgTeam !== playerTeam) {

--- a/client/src/input/input-keyboard.js
+++ b/client/src/input/input-keyboard.js
@@ -231,6 +231,12 @@ export const setupKeyboardInputs = (game) => {    //Capture the keyboard arrow k
                 return;
             }
         }
+        if (game?.itemFactory && typeof game.itemFactory.pickupFriendlyMine === 'function') {
+            const handled = game.itemFactory.pickupFriendlyMine();
+            if (handled) {
+                return;
+            }
+        }
         if (game?.iconFactory && typeof game.iconFactory.pickupIcon === 'function') {
             game.iconFactory.pickupIcon();
         }


### PR DESCRIPTION
## Summary
- allow friendly players to collide with mines and reclaim them via the pickup key
- send hazard removal payloads with reasons and re-add reclaimed mines to city inventory server-side
- cover mine pickup flow with updated hazard manager tests

## Testing
- npm test --prefix server
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e49e027f0832a8ac1a84160353cd4)