### PR TITLE
Stabilize ground tile positioning

### DIFF
--- a/client/src/draw/draw-ground.js
+++ b/client/src/draw/draw-ground.js
@@ -1,32 +1,48 @@
+const TILE_SIZE = 128;
+const REDRAW_RADIUS_TILES = 5;
+
 var minX = 0;
 var maxX = 0;
 var minY = 0;
 var maxY = 0;
 
+const modulo = (value, divisor) => {
+    const remainder = value % divisor;
+    return remainder < 0 ? remainder + divisor : remainder;
+};
 
 export const drawGround = (game, groundTiles) => {
+    if (!game || !groundTiles || !game.player || !game.player.offset || !game.player.defaultOffset) {
+        return;
+    }
 
+    const cameraX = Number.isFinite(game.player.offset.x) ? game.player.offset.x : 0;
+    const cameraY = Number.isFinite(game.player.offset.y) ? game.player.offset.y : 0;
+    const groundOffsetX = modulo(cameraX, TILE_SIZE);
+    const groundOffsetY = modulo(cameraY, TILE_SIZE);
+    const tileX = cameraX / TILE_SIZE;
+    const tileY = cameraY / TILE_SIZE;
 
-    var groundOffsetX = game.player.offset.x % 128; // Number of tank tiles on x axis
-    var groundOffsetY = game.player.offset.y % 128; // Number of tank tiles on y axis
-
-    if (game.player.offset.x / 128 > maxX
-        || game.player.offset.x / 128 < minX
-        || game.player.offset.y / 128 > maxY
-        || game.player.offset.y / 128 < minY
+    if (tileX > maxX
+        || tileX < minX
+        || tileY > maxY
+        || tileY < minY
     ) {
-        minX = (game.player.offset.x / 128) - 5;
-        maxX = (game.player.offset.x / 128) + 5;
-        minY = (game.player.offset.y / 128) - 5;
-        maxY = (game.player.offset.y / 128) + 5;
+        minX = tileX - REDRAW_RADIUS_TILES;
+        maxX = tileX + REDRAW_RADIUS_TILES;
+        minY = tileY - REDRAW_RADIUS_TILES;
+        maxY = tileY + REDRAW_RADIUS_TILES;
         groundTiles.clear();
         for (var i = -12; i < 12; i++) {
             for (var j = -12; j < 12; j++) {
-                groundTiles.addFrame(game.textures["groundTexture"], i * 128, j * 128);
+                groundTiles.addFrame(game.textures["groundTexture"], i * TILE_SIZE, j * TILE_SIZE);
             }
         }
-
-        groundTiles.position.set(game.player.defaultOffset.x + game.player.offset.x - groundOffsetX, game.player.defaultOffset.y + game.player.offset.y - groundOffsetY);
     }
-    groundTiles.pivot.set(game.player.offset.x, game.player.offset.y)
+
+    groundTiles.position.set(
+        game.player.defaultOffset.x + cameraX - groundOffsetX,
+        game.player.defaultOffset.y + cameraY - groundOffsetY
+    );
+    groundTiles.pivot.set(cameraX, cameraY);
 };


### PR DESCRIPTION
## Summary
- guard ground drawing for missing player state and reuse a consistent modulo for offsets
- refresh ground tile layer bounds using shared constants and update its position every frame to avoid gaps

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4bf3147c832a939d2ae7897cc186)