### PR TITLE
Enable cloak factory production

### DIFF
--- a/server/src/constants.js
+++ b/server/src/constants.js
@@ -16,7 +16,7 @@ const getFamilyCode = (type) => Math.floor(type / 100);
 
 const isHouse = (type) => getFamilyCode(type) === 3;
 const isResearch = (type) => getFamilyCode(type) === 4;
-const isFactory = (type) => getFamilyCode(type) === 1 && type !== 100;
+const isFactory = (type) => getFamilyCode(type) === 1;
 const isCommandCenter = (type) => type === 0;
 const HOSPITAL_TYPE_CODES = new Set([200, 301]);
 

--- a/server/test/factory-building.test.js
+++ b/server/test/factory-building.test.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const BuildingFactory = require("../src/BuildingFactory");
+const { POPULATION_MAX_NON_HOUSE } = require("../src/constants");
+const { ITEM_TYPES } = require("../src/items");
+
+test("cloak factory produces cloak icons when staffed", () => {
+    const game = { tick: 0 };
+    const factory = new BuildingFactory(game);
+    const emitted = [];
+
+    factory.io = {
+        emit: (event, payload) => emitted.push({ event, payload }),
+    };
+
+    factory.spawnStaticBuilding({ id: "house", x: 0, y: 0, type: 300, city: 1 });
+    const research = factory.spawnStaticBuilding({ id: "research", x: 1, y: 1, type: 400, city: 1 });
+    const cloakFactory = factory.spawnStaticBuilding({ id: "cloak", x: 2, y: 2, type: 100, city: 1 });
+
+    research.population = POPULATION_MAX_NON_HOUSE;
+    cloakFactory.population = POPULATION_MAX_NON_HOUSE;
+
+    game.tick = 8001;
+    factory.cycle();
+
+    const iconEvent = emitted.find((entry) => entry.event === "new_icon");
+    assert.ok(iconEvent, "expected cloak factory to emit a new icon");
+
+    const iconPayload = JSON.parse(iconEvent.payload);
+    assert.equal(iconPayload.type, ITEM_TYPES.CLOAK);
+    assert.equal(iconPayload.cityId, 1);
+    assert.equal(iconPayload.buildingId, cloakFactory.id);
+    assert.equal(cloakFactory.itemsLeft, 1);
+});


### PR DESCRIPTION
## Summary
- treat cloak factories as standard factories so they can produce cloak icons
- add a server test that verifies a staffed cloak factory emits cloak items once research is active

## Testing
- npm test --workspace server
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4daf02e8832a97c81793fa65d5d8)