### PR TITLE
Fix turret bullet team assignment

### DIFF
--- a/server/src/BulletFactory.js
+++ b/server/src/BulletFactory.js
@@ -192,9 +192,17 @@ class BulletFactory {
             }
         }
 
-        const teamId = (data.teamId !== undefined && data.teamId !== null)
-            ? data.teamId
-            : (this.playerFactory?.getPlayerTeam(socket.id) ?? null);
+        let teamId = null;
+        const teamRaw = data.team ?? data.teamId;
+        if (teamRaw !== undefined && teamRaw !== null) {
+            const numericTeam = Number(teamRaw);
+            if (Number.isFinite(numericTeam)) {
+                teamId = Math.floor(numericTeam);
+            }
+        }
+        if (teamId === null) {
+            teamId = this.playerFactory?.getPlayerTeam(socket.id) ?? null;
+        }
 
         this.registerSourceShot(sourceId, now);
 

--- a/server/test/bullet-team-resolution.test.js
+++ b/server/test/bullet-team-resolution.test.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const BulletFactory = require("../src/BulletFactory");
+
+const createFactory = () => {
+    const socketId = "player-socket";
+    const game = {
+        map: [[0]],
+        players: {
+            [socketId]: {
+                id: socketId,
+                city: 1,
+                offset: { x: 0, y: 0 }
+            }
+        }
+    };
+    const playerFactory = {
+        getPlayerTeam: () => 1
+    };
+    return { bulletFactory: new BulletFactory(game, playerFactory), socketId };
+};
+
+test("structure-fired bullets keep provided team assignments", () => {
+    const { bulletFactory, socketId } = createFactory();
+
+    bulletFactory.handleRequestFire(
+        { id: socketId },
+        {
+            x: 100,
+            y: 100,
+            angle: 0,
+            type: 0,
+            team: 7,
+            sourceId: "turret-1",
+            sourceType: "turret"
+        }
+    );
+
+    assert.equal(bulletFactory.bullets.size, 1);
+    const [bullet] = bulletFactory.bullets.values();
+    assert.equal(bullet.teamId, 7);
+    assert.equal(bullet.sourceType, "turret");
+});


### PR DESCRIPTION
## Summary
- ensure structure-initiated bullets honor provided team identifiers when processed by the server
- add a regression test covering turret bullet team assignment

## Testing
- npm test (server) *(fails: CityFileLoader.test.js uses unsupported globals)*
- npm test (client)
- npm run lint *(fails: existing indentation and undefined-global errors in FakeCityManager.js and CityFileLoader.test.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224e8ad1c4832a8309b3efcd9b6f75)