### PR TITLE
Reset client state on reconnect

### DIFF
--- a/client/src/SocketListener.js
+++ b/client/src/SocketListener.js
@@ -61,6 +61,7 @@ class SocketListener extends EventEmitter2 {
         this.sequenceCounter = 0;
         this.lastServerSequence = 0;
         this.localShotCache = new Map();
+        this.hasConnectedOnce = false;
 
         this.on('bot:debug', (data) => {
             updateBotWaypoints(data);
@@ -77,6 +78,11 @@ class SocketListener extends EventEmitter2 {
         });
         this.io.on("connect", () => {
             console.log("connected");
+            const wasReconnecting = this.hasConnectedOnce;
+            this.hasConnectedOnce = true;
+            if (wasReconnecting) {
+                this.resetWorldState();
+            }
             this.sequenceCounter = 0;
             this.lastServerSequence = 0;
             this.emit("connected");
@@ -1421,6 +1427,32 @@ class SocketListener extends EventEmitter2 {
             return fallback;
         }
         return 0;
+    }
+
+    resetWorldState() {
+        if (!this.game) {
+            return;
+        }
+        if (this.game.bulletFactory && typeof this.game.bulletFactory.resetState === 'function') {
+            this.game.bulletFactory.resetState();
+        }
+        if (this.game.buildingFactory && typeof this.game.buildingFactory.resetState === 'function') {
+            this.game.buildingFactory.resetState();
+        }
+        if (this.game.iconFactory && typeof this.game.iconFactory.resetState === 'function') {
+            this.game.iconFactory.resetState();
+        }
+        if (this.game.itemFactory && typeof this.game.itemFactory.resetState === 'function') {
+            this.game.itemFactory.resetState();
+        }
+        if (this.game.defenseItems && typeof this.game.defenseItems.clear === 'function') {
+            this.game.defenseItems.clear();
+        }
+        this.game.otherPlayers = {};
+        this.game.buildings = {};
+        this.game.cities = [];
+        this.localShotCache.clear();
+        this.game.forceDraw = true;
     }
 
 

--- a/client/src/factories/BuildingFactory.js
+++ b/client/src/factories/BuildingFactory.js
@@ -101,6 +101,30 @@ class BuildingFactory {
         this.researchTimers = new Map();
     }
 
+    resetState() {
+        let node = this.getHead();
+        while (node) {
+            node = this.deleteBuilding(node, false);
+        }
+        this.buildingsById = {};
+        this.buildingsByCoord = {};
+        this.pendingBuildCosts.clear();
+        this.pendingDemolish.clear();
+        for (const timerId of this.researchTimers.values()) {
+            clearTimeout(timerId);
+        }
+        this.researchTimers.clear();
+        this.researchStatus.clear();
+        if (Array.isArray(this.game?.cities)) {
+            this.game.cities.forEach((city) => {
+                if (city && city.canBuild) {
+                    Object.assign(city.canBuild, { ...DEFAULT_CITY_CAN_BUILD });
+                }
+            });
+        }
+        this.game.forceDraw = true;
+    }
+
     cycle() {
     }
 

--- a/client/src/factories/BulletFactory.js
+++ b/client/src/factories/BulletFactory.js
@@ -78,6 +78,13 @@ class BulletFactory {
         this.bulletListHead = null;
     }
 
+    resetState() {
+        let node = this.getHead();
+        while (node) {
+            node = this.deleteBullet(node);
+        }
+    }
+
     isLocalBotBullet(bullet) {
         if (!bullet || !bullet.sourceType) {
             return false;

--- a/client/src/factories/IconFactory.js
+++ b/client/src/factories/IconFactory.js
@@ -7,6 +7,14 @@ class IconFactory {
         this.iconsById = new Map();
     }
 
+    resetState() {
+        let node = this.getHead();
+        while (node) {
+            node = this.deleteIcon(node);
+        }
+        this.iconsById.clear();
+    }
+
     generateIconId(prefix = "icon") {
         const base = this.game?.socketListener?.io?.id ?? "local";
         return `${prefix}_${base}_${Date.now()}_${Math.random().toString(16).slice(-6)}`;

--- a/client/src/factories/ItemFactory.js
+++ b/client/src/factories/ItemFactory.js
@@ -115,6 +115,20 @@ class ItemFactory {
         }
     }
 
+    resetState() {
+        let node = this.getHead();
+        while (node) {
+            node = this.deleteItem(node, { notifyServer: false });
+        }
+        this.itemsById.clear();
+        this.pendingHazards.clear();
+        this.pendingDefenseIds.clear();
+        this.socketBound = false;
+        this.nextLocalId = 0;
+        this.nextDefenseId = 0;
+        this.pendingOrbItems = [];
+    }
+
     bindSocketEvents(socketListener) {
         if (!socketListener || this.socketBound) {
             return;


### PR DESCRIPTION
## Summary
- add reset routines to client factories so buildings, bullets, icons, and items are cleared cleanly
- reset world state when sockets reconnect to avoid stale client entities after server restarts

## Testing
- npm test *(fails: defender navmask/pathfinding tests already failing in repo)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d609b938832a8a43a75153420400)