### PR TITLE
Periodically refresh hazard snapshots

### DIFF
--- a/server/src/hazards/HazardManager.js
+++ b/server/src/hazards/HazardManager.js
@@ -18,6 +18,7 @@ const HAZARD_TYPES = {
 };
 
 const HAZARD_REVEAL_DURATION_MS = 750;
+const HAZARD_REFRESH_INTERVAL_MS = 2000;
 
 const ITEM_TYPE_MAP = {
     3: HAZARD_TYPES.BOMB,
@@ -52,6 +53,7 @@ class HazardManager {
         this.io = null;
         this.hazards = new Map();
         this.pendingIdsBySocket = new Map();
+        this.lastSnapshotBroadcast = 0;
     }
 
     setIo(io) {
@@ -63,21 +65,37 @@ class HazardManager {
             return;
         }
         for (const hazard of this.hazards.values()) {
-            socket.emit('hazard:spawn', JSON.stringify({
-                id: hazard.id,
-                type: hazard.type,
-                x: hazard.x,
-                y: hazard.y,
-                ownerId: hazard.ownerId,
-                teamId: hazard.teamId,
-                active: !!hazard.active,
-                armed: !!hazard.armed,
-                detonateAt: hazard.detonateAt || null,
-                revealedAt: hazard.revealedAt || null,
-                triggeredBy: hazard.triggeredBy || null,
-                triggeredTeam: hazard.triggeredTeam ?? null
-            }));
+            this.emitHazardSnapshot(socket, hazard);
         }
+    }
+
+    broadcastSnapshot() {
+        if (!this.io || this.hazards.size === 0) {
+            return;
+        }
+        for (const hazard of this.hazards.values()) {
+            this.emitHazardSnapshot(this.io, hazard);
+        }
+    }
+
+    emitHazardSnapshot(target, hazard) {
+        if (!target || !hazard || typeof target.emit !== "function") {
+            return;
+        }
+        target.emit('hazard:spawn', JSON.stringify({
+            id: hazard.id,
+            type: hazard.type,
+            x: hazard.x,
+            y: hazard.y,
+            ownerId: hazard.ownerId,
+            teamId: hazard.teamId,
+            active: !!hazard.active,
+            armed: !!hazard.armed,
+            detonateAt: hazard.detonateAt || null,
+            revealedAt: hazard.revealedAt || null,
+            triggeredBy: hazard.triggeredBy || null,
+            triggeredTeam: hazard.triggeredTeam ?? null
+        }));
     }
 
     parsePayload(payload) {
@@ -388,6 +406,11 @@ class HazardManager {
         }
 
         const now = Date.now();
+
+        if (this.io && now - this.lastSnapshotBroadcast >= HAZARD_REFRESH_INTERVAL_MS) {
+            this.broadcastSnapshot();
+            this.lastSnapshotBroadcast = now;
+        }
 
         for (const hazard of Array.from(this.hazards.values())) {
             if (!hazard.active && hazard.cleanupAt && now >= hazard.cleanupAt) {


### PR DESCRIPTION
## Summary
- add a periodic hazard snapshot broadcast so clients refresh hazard visuals
- refactor hazard snapshot emission through a shared helper used for snapshots

## Testing
- npm test --prefix server

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a23cc956c832aaaac0ef3fdf1534a)