### PR TITLE
Snap client hazard placement to player tile

### DIFF
--- a/client/src/factories/ItemFactory.js
+++ b/client/src/factories/ItemFactory.js
@@ -589,7 +589,8 @@ class ItemFactory {
         let adjustedY = y;
 
         const shouldSnapDefense = DEFENSE_ITEM_TYPES.has(type) && options.snapToPlayer !== false && options.notifyServer !== false;
-        if (shouldSnapDefense) {
+        const shouldSnapHazard = HAZARD_ITEM_TYPES.has(type) && options.snapToPlayer !== false && options.notifyServer !== false;
+        if (shouldSnapDefense || shouldSnapHazard) {
             const dominantTile = this.getPlayerDominantTile(this.game?.player);
             if (dominantTile) {
                 adjustedX = dominantTile.x * TILE_SIZE;

--- a/server/src/hazards/HazardManager.js
+++ b/server/src/hazards/HazardManager.js
@@ -109,11 +109,13 @@ class HazardManager {
         if (!type) {
             return null;
         }
-        const x = Number(payload.x);
-        const y = Number(payload.y);
-        if (!Number.isFinite(x) || !Number.isFinite(y)) {
+        const rawX = Number(payload.x);
+        const rawY = Number(payload.y);
+        if (!Number.isFinite(rawX) || !Number.isFinite(rawY)) {
             return null;
         }
+        const x = Math.floor(rawX / TILE_SIZE) * TILE_SIZE;
+        const y = Math.floor(rawY / TILE_SIZE) * TILE_SIZE;
         const hazard = {
             id: (typeof payload.id === "string" && payload.id.length > 0) ? payload.id : `${socket.id}_${Date.now()}`,
             ownerId: socket.id,
@@ -196,11 +198,13 @@ class HazardManager {
         if (!type) {
             return null;
         }
-        const x = Number(payload.x);
-        const y = Number(payload.y);
-        if (!Number.isFinite(x) || !Number.isFinite(y)) {
+        const rawX = Number(payload.x);
+        const rawY = Number(payload.y);
+        if (!Number.isFinite(rawX) || !Number.isFinite(rawY)) {
             return null;
         }
+        const x = Math.floor(rawX / TILE_SIZE) * TILE_SIZE;
+        const y = Math.floor(rawY / TILE_SIZE) * TILE_SIZE;
         const hazard = {
             id: (typeof payload.id === "string" && payload.id.length > 0)
                 ? payload.id


### PR DESCRIPTION
## Summary
- snap client-side hazard drops to the player's dominant tile when notifying the server so bombs align with wall/turret placement
- retain grid snapping for remote hazard spawns to keep server updates aligned

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a233d1f8c832a982950aaf87a84f5)