### PR TITLE
Add coverage summary workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,13 +26,19 @@ jobs:
         run: npm run coverage --workspace server
 
       - name: Generate server coverage artifacts
-        run: npx --yes c8 report --reporter=cobertura --reporter=lcov --temp-dir=server/coverage --report-dir=server/coverage
+        run: |
+          mkdir -p server/coverage/tmp
+          mv server/coverage/coverage-*.json server/coverage/tmp/
+          npx --yes c8 report --reporter=cobertura --reporter=lcov --temp-dir=server/coverage --report-dir=server/coverage
 
       - name: Run client coverage
         run: npm run coverage --workspace client
 
       - name: Generate client coverage artifacts
-        run: npx --yes c8 report --reporter=cobertura --reporter=lcov --temp-dir=client/coverage --report-dir=client/coverage
+        run: |
+          mkdir -p client/coverage/tmp
+          mv client/coverage/coverage-*.json client/coverage/tmp/
+          npx --yes c8 report --reporter=cobertura --reporter=lcov --temp-dir=client/coverage --report-dir=client/coverage
 
       - name: Code Coverage Summary
         uses: irongut/CodeCoverageSummary@v1.3.0


### PR DESCRIPTION
## Summary
- add coverage workflow running server and client coverage jobs
- publish Cobertura reports and PR comment via code-coverage-summary action
- upload generated coverage artifacts for inspection

## Testing
- npm run coverage --workspace server

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aad57fedc832aa3d963156e5140ae)